### PR TITLE
fix(ci): aqua の version を修正

### DIFF
--- a/.github/workflows/aqua-update-checksum.yaml
+++ b/.github/workflows/aqua-update-checksum.yaml
@@ -15,17 +15,16 @@ jobs:
       # v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # v4.1.1
-      - uses:
-          aquaproj/aqua-installer@4551ec64e21bf0f557c2525135ff0bd2cba40ec7
+      - uses: aquaproj/aqua-installer@4551ec64e21bf0f557c2525135ff0bd2cba40ec7
         with:
-          aqua_version: v3.9.0
+          aqua_version: v2.56.5
           aqua_opts: '--config dot_config/aquaproj-aqua/aqua.yaml'
         env:
           AQUA_CONFIG: dot_config/aquaproj-aqua/aqua.yaml
+          AQUA_LOG_LEVEL: debug
       - name: Update aqua-checksums.json
         run: >
-          aqua update-checksum --all
-          --config dot_config/aquaproj-aqua/aqua.yaml
+          aqua update-checksum --all --config dot_config/aquaproj-aqua/aqua.yaml
         env:
           AQUA_CONFIG: dot_config/aquaproj-aqua/aqua.yaml
       - name: Autofix


### PR DESCRIPTION
aqua の version 指定が間違っており、
CI が失敗していたため